### PR TITLE
Switch to script based addon deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ The folloing variables are required for every cluster:
 |flavor_name|Optional: flavor used for the VM|
 |image_name|Optional: image used for the VM|
 |assign_fips|Optional: Always assign public IP to nodes|
+|root_volume_size|Optional: Size in GB of root volume (default: 50)|
 |volume_size|Optional: Size in GB of persistent volume for master (default: 20), should not be used for worker|
 |update_mode|Optional: Update mode for VMs|
 |generation|Optional: explicit node generation count to enforce recreation|

--- a/modules/access/node_config/create.sh
+++ b/modules/access/node_config/create.sh
@@ -25,4 +25,5 @@ header="$COPYRIGHT
 variable="node_config"
 locals=X
 
+cd "$(dirname "$0")"
 source ../create.sh

--- a/modules/access/node_config/node_config.tf
+++ b/modules/access/node_config/node_config.tf
@@ -47,6 +47,7 @@ locals {
   update_mode = "${var.update_mode == "" ? lookup(local.info,"update_mode",var.update_mode) : var.update_mode}"
   generation = "${var.generation == "" ? lookup(local.info,"generation",var.generation) : var.generation}"
   assign_fips = "${var.assign_fips == "" ? lookup(local.info,"assign_fips",var.assign_fips) : var.assign_fips}"
+  root_volume_size = "${var.root_volume_size == "" ? lookup(local.info,"root_volume_size",var.root_volume_size) : var.root_volume_size}"
   volume_size = "${var.volume_size == "" ? lookup(local.info,"volume_size",var.volume_size) : var.volume_size}"
 }
 
@@ -60,6 +61,7 @@ output "node_config" {
       update_mode = "${local.update_mode}"
       generation = "${local.generation}"
       assign_fips = "${local.assign_fips}"
+      root_volume_size = "${local.root_volume_size}"
       volume_size = "${local.volume_size}"
   }
 }
@@ -87,6 +89,9 @@ output "generation" {
 }
 output "assign_fips" {
   value = "${local.assign_fips}"
+}
+output "root_volume_size" {
+  value = "${local.root_volume_size}"
 }
 output "volume_size" {
   value = "${local.volume_size}"

--- a/modules/access/node_config/variables.tf
+++ b/modules/access/node_config/variables.tf
@@ -47,6 +47,11 @@ variable "assign_fips" {
   default = ""
 }
 
+variable "root_volume_size" {
+  type = "string"
+  default = ""
+}
+
 variable "volume_size" {
   type = "string"
   default = ""

--- a/modules/instance/nodes.tf
+++ b/modules/instance/nodes.tf
@@ -40,6 +40,7 @@ module "master_config" {
     count = "${var.master_count}"
     assign_fips = "${var.assign_master_fips}"
     volume_size = "${var.master_volume_size}"
+    root_volume_size = "50"
   }
 }
 
@@ -58,6 +59,7 @@ module "worker_config" {
     update_mode = "${var.node_update_mode}"
     count = "${var.worker_count}"
     assign_fips = "${var.assign_worker_fips}"
+    root_volume_size = "50"
   }
 }
 
@@ -92,6 +94,11 @@ module "master" {
   image_name         = "${module.master_config.image_name}"
   flavor_name        = "${module.master_config.flavor_name}"
 
+  root_volume_size   = "${module.master_config.root_volume_size}"
+  volume_size        = "${module.master_config.volume_size}"
+  device             = "${module.iaas.device}"
+  provide_storage    = true
+
   security_group     = "${module.iaas.security_group}"
   subnet_id          = "${module.iaas.subnet_id}"
 
@@ -110,9 +117,6 @@ module "master" {
   assets_inst_dir    = "${module.cluster.assets_inst_dir}"
   bootkube_inst_dir  = "${module.cluster.bootkube_inst_dir}"
   bootkube_image     = "${module.versions.bootkube}:${module.versions.bootkube_version}"
-  volume_size        = "${var.master_volume_size}"
-  device             = "${module.iaas.device}"
-  provide_storage    = true
   #provide_fips        = "${module.use_bastion.value ? "${var.assign_master_fips}" : "single"}"
   provide_fips       = "${module.master_config.assign_fips}"
 
@@ -163,6 +167,7 @@ module "worker" {
   node_count         = "${module.worker_config.count}"
   image_name         = "${module.worker_config.image_name}"
   flavor_name        = "${module.worker_config.flavor_name}"
+  root_volume_size   = "${module.master_config.root_volume_size}"
 
   security_group     = "${module.iaas.security_group}"
   subnet_id          = "${module.iaas.subnet_id}"

--- a/modules/instance/resources/bin/complete-cluster
+++ b/modules/instance/resources/bin/complete-cluster
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DIR="$(dirname "$0")"
+BOOT=/opt/bootkube/assets
 echo finalizing cluster setup
 
 source "$(dirname "$0")"/source_me
@@ -28,4 +29,23 @@ fi
 
 "$DIR/completeetcd.sh"
 
+if [ -d "$BOOT/addons" ]; then
+  for d in "$BOOT/addons"/*; do
+    if [ -d "$d" ]; then
+       if [ -x "$d/deploy" ]; then
+         echo "deploying addon $(basename "$d") with handler ..."
+         ( cd "$d"
+           ./deploy
+         )
+       else
+         echo "deploying addon $(basename "$d") from manifests ..."
+         for f in "$d/manifests"/*.{yaml,yml}; do
+           if [ -f "$f" ]; then
+             kubectl apply -f "$f"
+           fi
+         done
+       fi
+    fi
+  done
+fi
 echo "cluster setup done"

--- a/modules/nodes/nodes.tf
+++ b/modules/nodes/nodes.tf
@@ -66,6 +66,10 @@ variable "volume_size" {
   type = "string"
   default = "20"
 }
+variable "root_volume_size" {
+  type = "string"
+  default = "50"
+}
 
 variable "tags" {
   type = "map"
@@ -393,6 +397,8 @@ module "vms" {
   security_group    = "${var.security_group}"
   iaas_info         = "${var.iaas_info}"
 
+  root_volume_size  = "${var.root_volume_size}"
+  volume_size       = "${var.volume_size}"
   provide_storage   = "${var.provide_storage}"
   provide_fips      = "${var.provide_fips}"
 

--- a/modules/seed/addons/monitoring/monitoring.tf
+++ b/modules/seed/addons/monitoring/monitoring.tf
@@ -245,3 +245,7 @@ output "generated" {
 output "manifests" {
   value="${path.module}/templates/manifests"
 }
+
+output "deploy" {
+  value=""
+}

--- a/modules/seed/scripts/copy_deploy
+++ b/modules/seed/scripts/copy_deploy
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -n "$2" ]; then
+  echo "copying $2 to $1"
+  mkdir -p "$1"
+  cp -f "$2" "$1"
+  chmod a+x "$1/$(basename "$2")"
+else 
+  echo "no deploy command for $(basename "$1")"
+fi

--- a/modules/seed/templates.tf
+++ b/modules/seed/templates.tf
@@ -142,11 +142,11 @@ resource "null_resource" "manifests" {
   depends_on = ["template_dir.bootkube" ]
   triggers {
     bootkube = "${template_dir.bootkube.id}"
-    addons   = "${join(",",template_dir.addons.*.id)}"
     backup   = "${module.etcd_backup_id.value}"
     iaas     = "${var.addon_trigger}"
     script   = "${sha256(file("${path.module}/scripts/prepare_assets.sh"))}"
-    command  = "${path.module}/scripts/prepare_assets.sh \"${var.gen_dir}/assets\" \"${var.gen_dir}/bootkube\" ${join(" ",formatlist("${var.gen_dir}/addons/%s",concat(local.selected,list("distinct"))))} \"${module.iaas-addons.value}\""
+    #command  = "${path.module}/scripts/prepare_assets.sh \"${var.gen_dir}/assets\" \"${var.gen_dir}/bootkube\" ${join(" ",formatlist("${var.gen_dir}/addons/%s",concat(local.selected,list("distinct"))))} \"${module.iaas-addons.value}\""
+    command  = "${path.module}/scripts/prepare_assets.sh \"${var.gen_dir}/assets\" \"${var.gen_dir}/bootkube\" \"${var.gen_dir}/addons/distinct\" \"${module.iaas-addons.value}\""
   }
 
   provisioner "local-exec" {
@@ -162,6 +162,8 @@ resource "null_resource" "archive_deps" {
   depends_on = [ "template_dir.bootkube", "local_file.cluster_info", "local_file.kubelet_conf", "module.kubelet", "module.apiserver", "module.etcd", "module.etcd-client", "null_resource.etcd_backup" ]
   triggers {
     cluster_info = "${local_file.cluster_info.id}"
+    addon_deploy   = "${join(",",null_resource.deploy.*.id)}"
+    addons   = "${join(",",template_dir.addons.*.id)}"
     manifests = "${null_resource.manifests.id}"
     backup   = "${module.etcd_backup_id.value}"
     recover = "${var.vm_version}"

--- a/platforms/aws/modules/vms/vms.tf
+++ b/platforms/aws/modules/vms/vms.tf
@@ -77,6 +77,10 @@ resource "aws_instance" "nodes" {
   disable_api_termination = false
   source_dest_check  = false
 
+  root_block_device {
+    volume_size = "${var.root_volume_size}"
+  }
+  
   iam_instance_profile = "${module.instance_profile.value}"
 
   tags = "${merge(module.tags.value, var.tags, map("Name", "${var.prefix}-${var.node_type}-${count.index}"))}"

--- a/platforms/azure/modules/vms/vms.tf
+++ b/platforms/azure/modules/vms/vms.tf
@@ -76,7 +76,7 @@ resource "azurerm_virtual_machine" "storage" {
     managed_disk_type = "Standard_LRS"
     caching       = "None"
     create_option = "FromImage"
-    disk_size_gb  = "50"
+    disk_size_gb  = "${var.root_volume_size}"
   }
 
   storage_data_disk {
@@ -132,7 +132,7 @@ resource "azurerm_virtual_machine" "nostorage" {
     managed_disk_type = "Standard_LRS"
     caching       = "None"
     create_option = "FromImage"
-    disk_size_gb  = "50"
+    disk_size_gb  = "${var.root_volume_size}"
   }
 
   tags {

--- a/platforms/interfaces/vms
+++ b/platforms/interfaces/vms
@@ -53,6 +53,10 @@ variable "cloud_init" {
 variable "security_group" {
   type = "string"
 }
+variable "root_volume_size" {
+  type = "string"
+  default = "50"
+}
 variable "volume_size" {
   type = "string"
   default = "20"

--- a/platforms/openstack/modules/iaas/bastion.tf
+++ b/platforms/openstack/modules/iaas/bastion.tf
@@ -32,6 +32,7 @@ module "bastion" {
   image_name        = "${module.bastion_config.image_name}"
   flavor_name       = "${module.bastion_config.flavor_name}"
 
+  root_volume_size  = "40"
   key               = "${openstack_compute_keypair_v2.ssh_key.name}"
 
   subnet_id         = "${openstack_networking_subnet_v2.cluster.id}"

--- a/platforms/openstack/modules/vms/vms.tf
+++ b/platforms/openstack/modules/vms/vms.tf
@@ -77,6 +77,7 @@ resource "openstack_compute_instance_v2" "storage" {
     destination_type      = "local"
     boot_index            = 0
     delete_on_termination = true
+    volume_size           = "${var.root_volume_size}"
   }
 
   block_device {
@@ -107,6 +108,15 @@ resource "openstack_compute_instance_v2" "nostorage" {
   force_delete = true
 
   metadata = "${merge(module.tags.value, map("Name", "${var.prefix}-${var.node_type}-${count.index}"))}"
+
+  block_device {
+    uuid                  = "${element(module.roll.image_list, count.index)}"
+    source_type           = "image"
+    destination_type      = "local"
+    boot_index            = 0
+    delete_on_termination = true
+    volume_size           = "${var.root_volume_size}"
+  }
 
   network {
     uuid = "${lookup(var.iaas_info, "network_id")}"


### PR DESCRIPTION
So far, all addonns were deployed via bootkube.
For the gardener we require dedicated logic to delay parts of the deployments
until the extension api server is ready. Therefore we switch to script based
addon deployment handled by the `complete-cluster` script executed after
`bootkube`.