### PR TITLE
Added hypervisor anti-affinity to OpenStack instances

### DIFF
--- a/platforms/openstack/modules/iaas/iaas.tf
+++ b/platforms/openstack/modules/iaas/iaas.tf
@@ -112,11 +112,16 @@ resource "openstack_networking_secgroup_rule_v2" "cluster_tcp_all" {
   security_group_id = "${openstack_networking_secgroup_v2.cluster.id}"
 }
 
+resource "openstack_compute_servergroup_v2" "nodes" {
+  name     = "${var.prefix}-servergroup"
+  policies = ["anti-affinity"]
+}
 
 module "iaas_info" {
   source = "../../../../modules/mapvar"
   value = {
     network_id        = "${openstack_networking_network_v2.cluster.id}"
+    server_group_id   = "${openstack_compute_servergroup_v2.nodes.id}"
   }
 }
 

--- a/platforms/openstack/modules/vms/vms.tf
+++ b/platforms/openstack/modules/vms/vms.tf
@@ -58,11 +58,6 @@ module "tags" {
   }
 }
 
-resource "openstack_compute_servergroup_v2" "nodes" {
-  name     = "${var.prefix}-servergroup"
-  policies = ["anti-affinity"]
-}
-
 resource "openstack_compute_instance_v2" "storage" {
   count           = "${module.storage.value * var.node_count}"
   name            = "${var.prefix}-${var.node_type}-${count.index}"
@@ -75,7 +70,7 @@ resource "openstack_compute_instance_v2" "storage" {
   force_delete = true
 
   scheduler_hints {
-    group = "${openstack_compute_servergroup_v2.nodes.id}"
+    group = "${lookup(var.iaas_info, "server_group_id")}"
   }
 
   metadata = "${merge(module.tags.value, map("Name", "${var.prefix}-${var.node_type}-${count.index}"))}"
@@ -117,7 +112,7 @@ resource "openstack_compute_instance_v2" "nostorage" {
   force_delete = true
 
   scheduler_hints {
-    group = "${openstack_compute_servergroup_v2.nodes.id}"
+    group = "${lookup(var.iaas_info, "server_group_id")}"
   }
 
   metadata = "${merge(module.tags.value, map("Name", "${var.prefix}-${var.node_type}-${count.index}"))}"

--- a/platforms/openstack/modules/vms/vms.tf
+++ b/platforms/openstack/modules/vms/vms.tf
@@ -58,6 +58,11 @@ module "tags" {
   }
 }
 
+resource "openstack_compute_servergroup_v2" "nodes" {
+  name     = "${var.prefix}-servergroup"
+  policies = ["anti-affinity"]
+}
+
 resource "openstack_compute_instance_v2" "storage" {
   count           = "${module.storage.value * var.node_count}"
   name            = "${var.prefix}-${var.node_type}-${count.index}"
@@ -68,6 +73,10 @@ resource "openstack_compute_instance_v2" "storage" {
   security_groups = ["${var.security_group}"]
   availability_zone = "${module.os.availability_zone}"
   force_delete = true
+
+  scheduler_hints {
+    group = "${openstack_compute_servergroup_v2.nodes.id}"
+  }
 
   metadata = "${merge(module.tags.value, map("Name", "${var.prefix}-${var.node_type}-${count.index}"))}"
 
@@ -106,6 +115,10 @@ resource "openstack_compute_instance_v2" "nostorage" {
   security_groups = ["${var.security_group}"]
   availability_zone = "${module.os.availability_zone}"
   force_delete = true
+
+  scheduler_hints {
+    group = "${openstack_compute_servergroup_v2.nodes.id}"
+  }
 
   metadata = "${merge(module.tags.value, map("Name", "${var.prefix}-${var.node_type}-${count.index}"))}"
 


### PR DESCRIPTION
Added a `server_group_v2` resource with an anti-affinity scheduling hit. This group is referenced in the corresponding master and worker instances.