### PR TITLE
Remove Openstack provider deprecation for router_v2 property

### DIFF
--- a/platforms/openstack/modules/iaas/iaas.tf
+++ b/platforms/openstack/modules/iaas/iaas.tf
@@ -44,7 +44,7 @@ data "openstack_networking_network_v2" "fip" {
 
 resource "openstack_networking_router_v2" "cluster" {
   name             = "${var.prefix}"
-  external_gateway = "${data.openstack_networking_network_v2.fip.id}"
+  external_network_id = "${data.openstack_networking_network_v2.fip.id}"
   region           = "${module.os.region}"
 }
 


### PR DESCRIPTION
The `external_gateway` property for the router resource has been deprecated [1].

[1] https://www.terraform.io/docs/providers/openstack/r/networking_router_v2.html#external_gateway