### PR TITLE
Replace MAINTAINERS.md by CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# kubify maintainers
+* 	@mandelsoft @afritzler @gonzolino

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,0 @@
-Maintainers of this repository with their focus areas:
-
-* Uwe Krueger <uwe.krueger@sap.com> @mandelsoft
-* Andreas Fritzler <andreas.fritzler@sap.com> @afritzler
-* Daniel Gonzalez <daniel.gonzalez.nothnagel@sap.com> @gonzolino


### PR DESCRIPTION
This enables use of the Github codeowners feature
https://help.github.com/articles/about-codeowners/