### PR TITLE
add ca for signing

### DIFF
--- a/modules/seed/templates.tf
+++ b/modules/seed/templates.tf
@@ -113,6 +113,7 @@ locals {
     service_account_pub_b64 = "${base64encode(var.service_account_public_key_pem)}"
     service_account_key_b64 = "${base64encode(var.service_account_private_key_pem)}"
     controller_manager_ca_crt_b64 = "${module.apiserver.ca_cert_b64}"
+    controller_manager_ca_key_b64 = "${module.apiserver.ca_key_b64}"
     dns_version = "${module.versions.dns_version}"
     dns_service_ip = "${var.dns_service_ip}"
     flannel_version = "${module.versions.flannel_version}"

--- a/modules/seed/templates/bootkube/common/manifests/kube-controller-manager-secret.yaml
+++ b/modules/seed/templates/bootkube/common/manifests/kube-controller-manager-secret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
   ca.crt: "${controller_manager_ca_crt_b64}"
+  ca.key: "${controller_manager_ca_key_b64}"
   service-account.key: "${service_account_key_b64}"
 kind: Secret
 metadata:

--- a/modules/seed/templates/bootkube/common/manifests/kube-controller-manager.yaml
+++ b/modules/seed/templates/bootkube/common/manifests/kube-controller-manager.yaml
@@ -54,6 +54,8 @@ spec:
         - --leader-elect=true
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+        - --cluster-signing-cert-file=/etc/kubernetes/secrets/ca.crt
+        - --cluster-signing-key-file=/etc/kubernetes/secrets/ca.key
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This PR adds the `--cluster-signing-cert-file` and `--cluster-signing-key-file` flags to the kube-controller-manager deployment and the ca key file to the corresponding secret. That allows the kubify cluster to sign CSRs with the cluster ca.