### PR TITLE
openstack dns provider designate integration

### DIFF
--- a/modules/dns/designate/designate.tf
+++ b/modules/dns/designate/designate.tf
@@ -1,0 +1,79 @@
+# Copyright (c) 2017 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+variable "entry_count" {
+  default = 0
+}
+variable "name_count" {
+  default = 1
+}
+variable "target" {
+  default = ""
+}
+variable "targets" {
+  default = []
+}
+variable "type" {
+  type = "string"
+}
+variable "name" {
+  type = "string"
+  default = ""
+}
+variable "names" {
+  type = "list"
+  default = [ ]
+}
+variable "ttl" {
+  default = 300
+}
+
+variable "config" {
+  type = "map"
+}
+
+variable "active" {
+  default = false
+}
+
+
+module "dns_hostedzone" {
+  source = "../../configurable"
+  optional = "${! var.active}"
+  value  = "${lookup(var.config,"hosted_zone_id")}"
+}
+
+locals {
+  names = "${compact(concat(list(var.name),var.names))}"
+}
+
+resource "openstack_dns_recordset_v2" "record" {
+  provider = "openstack"
+  count    = "${var.active * var.name_count * (1 - signum(var.entry_count))}" 
+  zone_id  = "${module.dns_hostedzone.value}"
+  name     = "${element(local.names,count.index)}"
+  type     = "${var.type}"
+  ttl      = "${var.ttl}"
+  records  = ["${var.target}"]
+}
+resource "openstack_dns_recordset_v2" "records" {
+  provider = "openstack"
+  count    = "${var.active * var.entry_count }"
+  zone_id  = "${module.dns_hostedzone.value}"
+  name     = "${var.names[count.index]}"
+  type     = "${var.type}"
+  ttl      = "${var.ttl}"
+  records  = ["${element(var.targets,count.index)}"]
+}

--- a/modules/dns/dns.tf
+++ b/modules/dns/dns.tf
@@ -70,7 +70,7 @@ module "active" {
 module "dns" {
   source = "../value_check"
   value = "${lookup(var.config,"dns_type")}"
-  values = [ "route53" ]
+  values = [ "route53", "designate" ]
 }
 
 module "route53_dns" {
@@ -95,3 +95,24 @@ module "route53" {
   config = "${var.config}"
 }
 
+module "os_dns" {
+  source = "../flag"
+  option = "${module.dns.value == "designate"}"
+}
+
+module "designate" {
+  source = "./designate"
+
+  active = "${module.active.if_active * module.os_dns.if_active}"
+
+  entry_count  = "${var.entry_count}"
+  name_count  = "${var.name_count}"
+  target = "${var.target}"
+  targets= "${var.targets}"
+  type   = "${var.type}"
+  name   = "${var.name}"
+  names  = "${var.names}"
+  ttl    = "${var.ttl}"
+
+  config = "${var.config}"
+}

--- a/modules/seed/addons/external-dns/external-dns.tf
+++ b/modules/seed/addons/external-dns/external-dns.tf
@@ -54,6 +54,7 @@ locals {
   provider_map = {
     aws = "aws"
     route53 = "aws"
+    designate = "openstack"
   }
 
   defaults = {


### PR DESCRIPTION
currently only have aws Route53 dns provider, under openstack private cloud, cannot use public cloud dns service, the pr would use openstack designate as the dns provide